### PR TITLE
feat(template): add ruleset JSON files from gist

### DIFF
--- a/.github/rulesets/integration-branch-protection.json
+++ b/.github/rulesets/integration-branch-protection.json
@@ -1,0 +1,20 @@
+{
+  "name": "integration-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/integration"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/integration-pr-reviews.json
+++ b/.github/rulesets/integration-pr-reviews.json
@@ -1,0 +1,31 @@
+{
+  "name": "integration-pr-reviews",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/integration"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,23 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/main-pr-reviews.json
+++ b/.github/rulesets/main-pr-reviews.json
@@ -1,0 +1,31 @@
+{
+  "name": "main-pr-reviews",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add GitHub ruleset JSON files from `templates.hbs(github/rulesets)` gist to `.github/rulesets/` directory.

## Files Added

| File | Purpose |
|------|---------|
| `main-branch-protection.json` | Prevent deletion, force push, require linear history |
| `main-pr-reviews.json` | Require 1 approval, dismiss stale reviews, resolve threads |
| `integration-branch-protection.json` | Same protections for integration branch |
| `integration-pr-reviews.json` | Same review requirements for integration branch |

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)